### PR TITLE
Fix last in seqs

### DIFF
--- a/funcy/seqs.py
+++ b/funcy/seqs.py
@@ -57,7 +57,7 @@ def last(seq):
             return None
 
     item = None
-    for item in iter(l):
+    for item in iter(seq):
         pass
     return item
 


### PR DESCRIPTION
I received 
`NameError: global name 'l' is not defined`
on doing

``` python
last(iter(some_list))
```
