### PR TITLE
find_where: Like where(), but stops at the first matched item

### DIFF
--- a/docs/colls.rst
+++ b/docs/colls.rst
@@ -222,6 +222,12 @@ Data manipulation
         # => [{"title": "Cymbeline", "author": "Shakespeare", "year": 1611},
         #     {"title": "The Tempest", "author": "Shakespeare", "year": 1611}]
 
+.. function:: find_where(mappings, **cond)
+
+    Returns the first value in a given sequence of dicts that contains all of the key-value pairs in ``cond``::
+
+        find_where(plays, title="Cymbeline")
+        # => {"title": "Cymbeline", "author": "Shakespeare", "year": 1611}
 
 .. function:: pluck(key, mappings)
 

--- a/funcy/colls.py
+++ b/funcy/colls.py
@@ -18,7 +18,7 @@ __all__ = ['empty', 'iteritems', 'itervalues',
            'walk', 'walk_keys', 'walk_values', 'select', 'select_keys', 'select_values', 'compact',
            'is_distinct', 'all', 'any', 'none', 'one', 'some',
            'zipdict', 'flip', 'project', 'izip_values', 'izip_dicts',
-           'where', 'pluck', 'pluck_attrs', 'invoke',
+           'where', 'find_where', 'pluck', 'pluck_attrs', 'invoke',
            'get_in', 'set_in', 'update_in']
 
 
@@ -246,6 +246,10 @@ def update_in(coll, path, update, default=None):
 def where(mappings, **cond):
     match = lambda m: all(m[k] == v for k, v in cond.items())
     return filter(match, mappings)
+
+def find_where(mappings, **cond):
+    match = lambda m: all(m[k] == v for k, v in cond.items())
+    return next(ifilter(match, mappings), None)
 
 def pluck(key, mappings):
     return map(itemgetter(key), mappings)

--- a/tests/test_colls.py
+++ b/tests/test_colls.py
@@ -262,7 +262,7 @@ def test_find_where():
     data = [{'a': 1, 'b': 2}, {'a': 1, 'b': 3}, {'a': 10, 'b': 2}]
     assert find_where(data, a=1) == {'a': 1, 'b': 2}
     assert find_where(data, a=1, b=3) == {'a': 1, 'b': 3}
-    assert find_where(data, a=1, b=5) == None
+    assert find_where(data, a=1, b=5) is None
 
 def test_pluck():
     data = [{'a': 1, 'b': 2}, {'a': 10, 'b': 2}]

--- a/tests/test_colls.py
+++ b/tests/test_colls.py
@@ -258,6 +258,12 @@ def test_where():
     assert where(data, a=1, b=2) == [{'a': 1, 'b': 2}]
     assert where(data, b=2) == data
 
+def test_find_where():
+    data = [{'a': 1, 'b': 2}, {'a': 1, 'b': 3}, {'a': 10, 'b': 2}]
+    assert find_where(data, a=1) == {'a': 1, 'b': 2}
+    assert find_where(data, a=1, b=3) == {'a': 1, 'b': 3}
+    assert find_where(data, a=1, b=5) == None
+
 def test_pluck():
     data = [{'a': 1, 'b': 2}, {'a': 10, 'b': 2}]
     assert pluck('a', data) == [1, 10]


### PR DESCRIPTION
Thanks again for the neat library.

`find_where()` can be accomplished with `next(where(), None)`, but this is a pretty common use case and seems worth adding.

If you decide not to add this, could you explain how `where` and `iwhere` are intended to be used in Python 2.7? Am I supposed to use `from funcy.colls import iwhere`, and then `next(iwhere(...), None)`?