### PR TITLE
Make get_in, set_in work with lists/indexables

### DIFF
--- a/funcy/colls.py
+++ b/funcy/colls.py
@@ -224,9 +224,9 @@ def izip_dicts(*dicts):
 
 def get_in(coll, path, default=None):
     for key in path:
-        if key in coll:
+        try:
             coll = coll[key]
-        else:
+        except (IndexError, TypeError, KeyError):  # First two for list indexing, last for dict
             return default
     return coll
 
@@ -234,9 +234,14 @@ def set_in(coll, path, value):
     if not path:
         return value
     else:
-        copy = coll.copy()
-        copy[path[0]] = set_in(copy.get(path[0], {}), path[1:], value)
-        return copy
+        if isinstance(coll, list):
+            copy = coll[:]
+            copy[path[0]] = set_in(coll[path[0]], path[1:], value)
+            return copy
+        else:
+            copy = coll.copy()
+            copy[path[0]] = set_in(copy.get(path[0], {}), path[1:], value)
+            return copy
 
 def update_in(coll, path, update, default=None):
     value = update(get_in(coll, path, default))

--- a/tests/test_colls.py
+++ b/tests/test_colls.py
@@ -203,23 +203,29 @@ def test_izip_dicts():
     assert list(izip_dicts({1: 10}, {1: 20, 2: 30})) == [(1, (10, 20))]
     with pytest.raises(TypeError): list(izip_dicts())
 
-
 def test_get_in():
     d = {
-        "a": {
-            "b": "c",
-            "d": "e",
-            "f": {
-                "g": "h"
+        'a': {
+            'b': 'c',
+            'd': 'e',
+            'arr': [1, 2, 3, {
+                'a3': 'b3'
+            }],
+            'f': {
+                'g': 'h'
             }
         },
-        "i": "j"
+        'i': 'j',
     }
-    assert get_in(d, ["m"]) is None
-    assert get_in(d, ["m", "n"], "foo") == "foo"
-    assert get_in(d, ["i"]) == "j"
-    assert get_in(d, ["a", "b"]) == "c"
-    assert get_in(d, ["a", "f", "g"]) == "h"
+    assert get_in(d, ['m']) is None
+    assert get_in(d, ['m', 'n'], 'foo') == 'foo'
+    assert get_in(d, ['i']) == 'j'
+    assert get_in(d, ['a', 'b']) == 'c'
+    assert get_in(d, ['a', 'f', 'g']) == 'h'
+    assert get_in(d, ['a', 'arr', 0]) == 1
+    assert get_in(d, ['a', 'arr', 4]) is None
+    assert get_in(d, ['a', 'arr', 'stringkey']) is None
+    assert get_in(d, ['a', 'arr', 3, 'a3']) == 'b3'
 
 def test_set_in():
     d = {
@@ -227,6 +233,7 @@ def test_set_in():
             'b': 1,
             'c': 2,
         },
+        'arr': [{'g': 'h'}, 'f'],
         'd': 5
     }
 
@@ -237,6 +244,10 @@ def test_set_in():
     d3 = set_in(d, ['e', 'f'], 42)
     assert d3['e'] == {'f': 42}
     assert d3['a'] is d['a']
+
+    d4 = set_in(d, ['arr', 1], 'q')
+    assert d4['arr'][1] == 'q'
+    assert d4['arr'][0] is d['arr'][0]
 
 def test_update_in():
     d = {'c': []}


### PR DESCRIPTION
Currently:
```python
def get_in(coll, path, default=None):
    for key in path:
        if key in coll:
            coll = coll[key]
        else:
            return default
    return coll
```

With current implementation, `get_in([1, 2, 3, 4], [0])` returns `None`, while `get_in([1,2,3,4], [1])` returns `2`, due to the `in` behavior, which is slightly funky.

I've modified `get_in` and `set_in` to work with more general indexables - `set_in` only with lists but
`get_in` with general indexables.

If this change sounds good, happy to add to docs as well.

Thanks!