### PR TITLE
fix retry called with list of errors

### DIFF
--- a/funcy/flow.py
+++ b/funcy/flow.py
@@ -72,6 +72,10 @@ except ImportError:
 
 @decorator
 def retry(call, tries, errors=Exception, timeout=0):
+    if isinstance(errors, list):
+        # because `except` does not catch exceptions from list
+        errors = tuple(errors)
+
     for attempt in xrange(tries):
         try:
             return call()

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -85,6 +85,20 @@ def test_retry_timeout():
     assert 0.07 < d < 0.08
 
 
+def test_retry_many_errors():
+    calls = []
+
+    def failing(n=1):
+        if len(calls) < n:
+            calls.append(1)
+            raise MyError
+        return 1
+
+    assert retry(2, (MyError, RuntimeError))(failing)() == 1
+    calls = []
+    assert retry(2, [MyError, RuntimeError])(failing)() == 1
+
+
 def test_fallback():
     assert fallback(raiser(), lambda: 1) == 1
     with pytest.raises(Exception): fallback((raiser(), MyError), lambda: 1)


### PR DESCRIPTION
I run into the problem: `retry` silently does not work if `errors` argument passed as list, but works perfectly if errors is a tuple. I think it unfairly.