### PR TITLE
Add test for bug with None in dict

### DIFF
--- a/tests/test_colls.py
+++ b/tests/test_colls.py
@@ -231,6 +231,11 @@ def test_get_in_list():
     assert get_in({'x': [1, 2]}, ['x', 1]) == 2
 
 
+def test_get_in_with_None():
+    d = {'foo': None}
+    assert get_in(d, ['foo', 'bar']) is None
+
+
 def test_set_in():
     d = {
         'a': {


### PR DESCRIPTION
It seems that I have found a bug. 
If you use get_in and somewhere in your path you get `None` it fails.  

``` python
____________________________ test_get_in_with_None _____________________________

    def test_get_in_with_None():
        d = {'foo': None}
>       assert get_in(d, ['foo', 'bar']) is None

tests/test_colls.py:236: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

coll = None, path = ['foo', 'bar'], default = None

    def get_in(coll, path, default=None):
        for key in path:
            try:
>               coll = coll[key]
E               TypeError: 'NoneType' object has no attribute '__getitem__'

funcy/colls.py:228: TypeError
```

What do you think about this behaviour? As for me, it should be fixed.
