### PR TITLE
New function complementary to project()

### DIFF
--- a/docs/cheatsheet.rst
+++ b/docs/cheatsheet.rst
@@ -97,7 +97,7 @@ Collections
 Join                  :func:`merge` :func:`merge_with` :func:`join` :func:`join_with`
 Transform             :func:`walk` :func:`walk_keys` :func:`walk_values`
 Filter                :func:`select` :func:`select_keys` :func:`select_values` :func:`compact`
-Dicts :ref:`*<colls>` :func:`flip` :func:`zipdict` :func:`pluck` :func:`where` :func:`itervalues` :func:`iteritems` :func:`izip_values` :func:`izip_dicts` :func:`project`
+Dicts :ref:`*<colls>` :func:`flip` :func:`zipdict` :func:`pluck` :func:`where` :func:`itervalues` :func:`iteritems` :func:`izip_values` :func:`izip_dicts` :func:`project` :func:`throw`
 Misc                  :func:`empty` :func:`get_in` :func:`set_in` :func:`update_in`
 ===================== ==============================================================
 

--- a/docs/colls.rst
+++ b/docs/colls.rst
@@ -165,6 +165,14 @@ Dict utils
         merge(project(__builtins__, names), project(globals(), names))
 
 
+.. function:: throw(mapping, keys)
+
+    Returns a dict containing only those entries in ``mapping`` whose key is **not** in ``keys``. Preserves collection type::
+
+        throw({'a': 1, 'b': 2, 'c': 3}, 'ac')
+        # -> {'b': 2}
+
+
 .. function:: izip_values(*dicts)
 
     Yields tuples of corresponding values of given dicts. Skips any keys not present in all of the dicts. Comes in handy when comparing two or more dicts::
@@ -339,5 +347,3 @@ Low-level helpers
 
         list(itervalues({'a': 1}))
         # -> [1]
-
-

--- a/funcy/colls.py
+++ b/funcy/colls.py
@@ -17,7 +17,7 @@ __all__ = ['empty', 'iteritems', 'itervalues',
            'join', 'merge', 'join_with', 'merge_with',
            'walk', 'walk_keys', 'walk_values', 'select', 'select_keys', 'select_values', 'compact',
            'is_distinct', 'all', 'any', 'none', 'one', 'some',
-           'zipdict', 'flip', 'project', 'izip_values', 'izip_dicts',
+           'zipdict', 'flip', 'project', 'throw', 'izip_values', 'izip_dicts',
            'where', 'pluck', 'pluck_attr', 'invoke', 'iwhere', 'ipluck', 'ipluck_attr', 'iinvoke',
            'get_in', 'set_in', 'update_in']
 
@@ -217,6 +217,9 @@ def flip(mapping):
 
 def project(mapping, keys):
     return _factory(mapping)((k, mapping[k]) for k in keys if k in mapping)
+
+def throw(mapping, keys):
+    return _factory(mapping)((k, v) for k, v in iteritems(mapping) if k not in keys)
 
 def izip_values(*dicts):
     if len(dicts) < 1:

--- a/tests/test_colls.py
+++ b/tests/test_colls.py
@@ -212,6 +212,11 @@ def test_project():
     dd = defaultdict(int, {'a':1, 'b':2, 'c': 3})
     assert eq(project(dd, 'ac'), defaultdict(int, {'a':1, 'c': 3}))
 
+def test_throw():
+    assert throw({'a': 1, 'b': 2, 'c': 3}, 'ac') == {'b': 2}
+    dd = defaultdict(int, {'a': 1, 'b': 2, 'c': 3})
+    assert eq(throw(dd, 'ac'), defaultdict(int, {'b': 2}))
+
 def test_izip_values():
     assert list(izip_values({1: 10}, {1: 20, 2: 30})) == [(10, 20)]
     with pytest.raises(TypeError): list(izip_values())


### PR DESCRIPTION
It would be great to have a function complementary to project(): construct a new dict from a given mapping which keys are **not** in a given sequence.