### PR TITLE
Don't crash in `where` on nonexistent keys from conditions

### DIFF
--- a/funcy/colls.py
+++ b/funcy/colls.py
@@ -295,7 +295,7 @@ def update_in(coll, path, update, default=None):
 
 def where(mappings, **cond):
     """Selects mappings containing all pairs in cond."""
-    match = lambda m: all(m[k] == v for k, v in cond.items())
+    match = lambda m: all(k in m and m[k] == v for k, v in cond.items())
     return filter(match, mappings)
 
 def pluck(key, mappings):
@@ -314,7 +314,7 @@ def invoke(objects, name, *args, **kwargs):
 # Iterator versions for python 3 interface
 def iwhere(mappings, **cond):
     """Iterates over mappings containing all pairs in cond."""
-    match = lambda m: all(m[k] == v for k, v in cond.items())
+    match = lambda m: all(k in m and m[k] == v for k, v in cond.items())
     return ifilter(match, mappings)
 
 def ipluck(key, mappings):

--- a/tests/test_colls.py
+++ b/tests/test_colls.py
@@ -308,3 +308,8 @@ def test_pluck_attr():
 
 def test_invoke():
     assert invoke(['abc', 'def', 'b'], 'find', 'b') == [1, -1, 0]
+
+def test_where_nonexistent_key():
+    data = [{'a': 1}, {'b': 2}]
+    assert where(data, a=1) == [{'a': 1}]
+    assert where(data, b=2) == [{'b': 2}]


### PR DESCRIPTION
This is a proposed fix for #54.

The main drawback of this solution is that the existence of each key in each mapping is now checked twice: once with `in`, and another time when actually accessing the key. It is however a very "clean" fix in that it doesn't introduce additional exception-handling complexity into the function.