### PR TITLE
Add unpack decorator

### DIFF
--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -154,3 +154,11 @@ def test_meta_attribtes():
 
     assert double_decorated.__wrapped__ is decorated
     assert double_decorated.__original__ is func
+
+
+def test_unpack():
+    @unpack
+    def process(foo, bar, baz):
+        return foo + bar + baz
+
+    assert process(('foo', 'bar'), {'baz': 'baz'}) == 'foobarbaz'


### PR DESCRIPTION
I propose to add a decorator which will unpack argument:
```
    def process(foo, bar):
        ...
    
    map(unpack(process), product(['foo1', 'foo2'], ['bar1', 'bar2']))
```
Is it a funcy way?