### PR TITLE
Add Tree Keys

### DIFF
--- a/funcy/py2.py
+++ b/funcy/py2.py
@@ -25,7 +25,7 @@ RENAMES = {}
 for name in ('map', 'filter', 'remove', 'keep', 'without', 'concat', 'cat', 'flatten',
              'mapcat', 'distinct', 'split', 'split_at', 'split_by', 'partition', 'chunks',
              'partition_by', 'reductions', 'sums', 'juxt',
-             'tree_leaves', 'tree_nodes',
+             'tree_leaves', 'tree_nodes', 'tree_keys',
              'where', 'pluck', 'pluck_attr', 'invoke'):
     RENAMES['l' + name] = name
     RENAMES[name] = 'i' + name

--- a/funcy/tree.py
+++ b/funcy/tree.py
@@ -1,8 +1,9 @@
 from collections import deque
 from .types import is_seqcont
+from .seqs import lflatten
 
 
-__all__ = ['tree_leaves', 'ltree_leaves', 'tree_nodes', 'ltree_nodes']
+__all__ = ['tree_leaves', 'ltree_leaves', 'tree_nodes', 'ltree_nodes', 'tree_keys', 'ltree_keys']
 
 
 def tree_leaves(root, follow=is_seqcont, children=iter):
@@ -49,12 +50,12 @@ def tree_keys(payload, parent=None):
         if parent:
             trail.append(parent)
         trail.append(node)
-        yield fn.lflatten(trail)
+        yield lflatten(trail)
         child = payload.get(node)
         if isinstance(child, dict):
             yield from tree_keys(child, parent=trail)
 
 
-def ltree_keys(payload: Dict) -> List:
+def ltree_keys(payload):
     """List version of tree_keys"""
     return list(tree_keys(payload))

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -21,3 +21,10 @@ def test_tree_nodes():
     ]
     assert ltree_nodes(1) == [1]
     assert ltree_nodes(3, follow=_ > 1, children=range) == [3, 0, 1, 2, 0, 1]
+
+
+def test_tree_keys():
+    assert ltree_keys({"a": 1}) == [["a"]]
+    assert ltree_keys({"a": 1, "b": 2}) == [['b'], ['a']]
+    assert ltree_keys({"a": {"a1": 3}, "b": 2}) == [['b'], ['a'], ['a', 'a1']]
+    assert ltree_keys({}) == []


### PR DESCRIPTION
Hi! Big fan of funcy - thought I'd add something that I find really useful and I believe fits in with the library. Basically, this function allows you to generate a list of keys within a nested dict. 

This can then be used to iterate over a dictionary and make sure you're able to access any level of nested dicts. For example:

Given 
```
payload = {
    "foo": "bar",
    "parent": {
        "val": True,
        "child": {
            "foo": "bar"
        }
    }
}
```
`ltree_keys` returns a list: `[['parent'], ['parent', 'child'], ['parent', 'child', 'foo'], ['parent', 'val'], ['foo']]`

That then works nicely with `funcy.get_in` and the like - for example: `fn.lmap(lambda x: type(fn.get_in(payload, x)), keys)`

Happy to make any updates or add anything else I may have missed.