### PR TITLE
Make `@cache.invalidate()` idempotent

### DIFF
--- a/funcy/calc.py
+++ b/funcy/calc.py
@@ -123,7 +123,7 @@ def cache(timeout, key_func=None):
             return result
 
         def invalidate(*args, **kwargs):
-            cache.pop(key_func(*args, **kwargs))
+            cache.pop(key_func(*args, **kwargs), None)
         wrapper.invalidate = invalidate
 
         def invalidate_all():

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -122,9 +122,7 @@ def test_cache():
     assert inc(0) == 1
     assert inc(1) == 2
     assert inc(0) == 1
-    inc.invalidate(0)
-    assert inc(0) == 1
-    assert calls == [0, 1, 0]
+    assert calls == [0, 1]
 
 
 def test_cache_mixed_args():
@@ -146,3 +144,33 @@ def test_cache_timedout():
     assert inc(0) == 1
     assert inc(0) == 1
     assert calls == [0, 0]
+
+
+def test_cache_invalidate():
+    calls = []
+
+    @cache(timeout=60)
+    def inc(x):
+        calls.append(x)
+        return x + 1
+
+    assert inc(0) == 1
+    assert inc(1) == 2
+    assert inc(0) == 1
+    assert calls == [0, 1]
+
+    inc.invalidate_all()
+    assert inc(0) == 1
+    assert inc(1) == 2
+    assert inc(0) == 1
+    assert calls == [0, 1, 0, 1]
+
+    inc.invalidate(1)
+    assert inc(0) == 1
+    assert inc(1) == 2
+    assert inc(0) == 1
+    assert calls == [0, 1, 0, 1, 1]
+
+    # ensure invalidate() is idempotent (doesn't raise KeyError on the 2nd call)
+    inc.invalidate(0)
+    inc.invalidate(0)


### PR DESCRIPTION
Problem: `invalidate()` raises `KeyError` if the key is missing.

That leads to a nasty behavior: code works under unit tests,
but raises the error in production (because of the `timeout`).

An especially nasty case is when some concurrency is involved,
where two writer threads execute some write operation simultaneously,
and then one thread wins the race, while another gets `KeyError`.

In practice, it is almost impossible to write any deterministic logic
that will do something like:
  "I know I mutated this specific thing, so invalidate the old value"

so I always have to do this:

    try:
        function_decorated_with_cache.invalidate(key)
    except KeyError:
        pass

And I guess everyone who faced this issue has to do the same,
so it looks to me more a bug than a feature.

So here I decided to fix it.
Now `invalidate()` just doesn't raise `KeyError` if the key is
missing.

Also, I've added a separate test dedicated to invalidation,
where I also added `invalidate_all()` (that wasn't covered by tests
previously).