### PR TITLE
Allow `into` argument of `reraise` to be callable

### DIFF
--- a/docs/flow.rst
+++ b/docs/flow.rst
@@ -87,6 +87,12 @@ Flow
         def api_call(...):
             # ...
 
+    ``into`` can also be a callable to transform the error before reraising::
+
+        @reraise(requests.RequestsError, lambda e: MyAPIError(error_desc(e)))
+        def api_call(...):
+            # ...
+
 
 .. decorator:: retry(tries, errors=Exception, timeout=0, filter_errors=None)
 

--- a/funcy/flow.py
+++ b/funcy/flow.py
@@ -111,7 +111,10 @@ def reraise(errors, into):
     try:
         yield
     except errors as e:
-        raise_from(into, e)
+        if callable(into) and not _is_exception(into):
+            raise_from(into(e), e)
+        else:
+            raise_from(into, e)
 
 
 @decorator
@@ -150,8 +153,12 @@ def fallback(*approaches):
 def _ensure_exceptable(errors):
     """Ensures that errors are passable to except clause.
        I.e. should be BaseException subclass or a tuple."""
-    is_exception = isinstance(errors, type) and issubclass(errors, BaseException)
-    return errors if is_exception else tuple(errors)
+    return errors if _is_exception(errors) else tuple(errors)
+
+
+def _is_exception(value):
+    """Is the given value an exception?"""
+    return isinstance(value, type) and issubclass(value, BaseException)
 
 
 class ErrorRateExceeded(Exception):

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -69,6 +69,10 @@ def test_reraise():
         with reraise(ValueError, MyError):
             raise TypeError
 
+    with pytest.raises(MyError):
+        with reraise(ValueError, lambda _: MyError):
+            raise ValueError
+
 
 def test_retry():
     with pytest.raises(MyError):


### PR DESCRIPTION
This PR tweaks `reraise()` to also accept any `callable` as a second argument. This allows users to transform any exceptions before they are re-raised without introducing helper functions or another `try ... except` block.