### PR TITLE
Fix tuple structure in the izip_dicts doc-string

### DIFF
--- a/funcy/colls.py
+++ b/funcy/colls.py
@@ -255,7 +255,7 @@ def izip_values(*dicts):
         yield tuple(d[key] for d in dicts)
 
 def izip_dicts(*dicts):
-    """Yields tuples like (key, val1, val2, ...)
+    """Yields tuples like (key, (val1, val2, ...))
        for each common key in all given dicts."""
     if len(dicts) < 1:
         raise TypeError('izip_dicts expects at least one argument')


### PR DESCRIPTION
The doc-string currently says `izip_dicts()` returns tuples of the form `(key, val1, val2, ...)`, but it actually returns tuples of the form `(key, (val1, val2, ...))`.