### PR TITLE
Preserve metadata when using autocurry as a decorator

### DIFF
--- a/funcy/funcs.py
+++ b/funcy/funcs.py
@@ -1,5 +1,5 @@
 from operator import __not__
-from functools import partial, reduce
+from functools import partial, reduce, wraps
 
 from .compat import map
 from ._inspect import get_spec, Spec
@@ -70,6 +70,7 @@ def autocurry(func, n=EMPTY, _spec=None, _args=(), _kwargs={}):
        until sufficient arguments are passed."""
     spec = _spec or (get_spec(func) if n is EMPTY else Spec(n, set(), n, set(), False))
 
+    @wraps(func)
     def autocurried(*a, **kw):
         args = _args + a
         kwargs = _kwargs.copy()

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -129,6 +129,15 @@ def test_autocurry_class():
     class I(int): pass
     assert autocurry(int)(base=12)('100') == 144
 
+def test_autocurry_docstring():
+
+    @autocurry
+    def f(a, b):
+        'docstring'
+
+    assert f.__doc__ == 'docstring'
+
+
 
 def test_compose():
     double = _ * 2


### PR DESCRIPTION
It seems convenient to use `autocurry` as a decorator, but doing so currently causes all of the metadata (i.e. docstrings, etc.) for the original function to be lost.  This PR simply uses `functools.wraps` to preserve that information.