### PR TITLE
use more precise timer `timeit.default_timer` for log_durations

### DIFF
--- a/funcy/debug.py
+++ b/funcy/debug.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 import re
-import time
 import traceback
 from itertools import chain
 from functools import partial
+from timeit import default_timer as timer
 
 from .compat import basestring
 from .decorators import decorator, wraps, Call
@@ -171,11 +171,11 @@ class log_durations(LabeledContextDecorator):
         self.threshold = threshold
 
     def __enter__(self):
-        self.start = time.time()
+        self.start = timer()
         return self
 
     def __exit__(self, *exc):
-        duration = time.time() - self.start
+        duration = timer() - self.start
         if duration >= self.threshold:
             duration_str = self.format_time(duration)
             self.print_func("%s in %s" % (duration_str, self.label) if self.label else duration_str)
@@ -191,9 +191,9 @@ def log_iter_durations(seq, print_func, label=None, unit='auto'):
     suffix = " of %s" % label if label else ""
     it = iter(seq)
     for i, item in enumerate(it):
-        start = time.time()
+        start = timer()
         yield item
-        duration = _format_time(time.time() - start)
+        duration = _format_time(timer() - start)
         print_func("%s in iteration %d%s" % (duration, i, suffix))
 
 def print_iter_durations(seq, label=None, unit='auto'):

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -118,7 +118,7 @@ def test_print_errors_recursion():
 
 def test_log_durations(monkeypatch):
     timestamps = iter([0, 0.01, 1, 1.000025])
-    monkeypatch.setattr('time.time', lambda: next(timestamps))
+    monkeypatch.setattr('funcy.debug.timer', lambda: next(timestamps))
     log = []
 
     f = log_durations(log.append)(lambda: None)
@@ -132,7 +132,7 @@ def test_log_durations(monkeypatch):
 def test_log_durations_ex(monkeypatch):
     timestamps = [0, 0.01, 1, 1.001, 2, 2.02]
     timestamps_iter = iter(timestamps)
-    monkeypatch.setattr('time.time', lambda: next(timestamps_iter))
+    monkeypatch.setattr('funcy.debug.timer', lambda: next(timestamps_iter))
     log = []
 
     f = log_durations(log.append, unit='ms', threshold=1.1e-3)(lambda: None)


### PR DESCRIPTION
Instead of using `time.time`, this uses \`timeit.default_timer()\`.
`default_timer` uses `time.perf_counter` which is monotonic,
is not user-adjustable, and is more precise.

However, `time.perf_counter` is only available since Python>3.3,
and hence is unavailable in Python 2.7. In that version, it defaults
to `time.clock()` in Windows and `time.time()` in other platforms.

I think a similar change should be made on `cache` and `throttle` functions.

From discussion in https://github.com/iterative/dvc/pull/7393#discussion_r854320578