### PR TITLE
feat($retry): enable capped exponential backoff and jitter via keyword arguments

### DIFF
--- a/funcy/flow.py
+++ b/funcy/flow.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-from math import inf
 from random import uniform
 import time
 import threading
@@ -119,7 +118,10 @@ def reraise(errors, into):
 
 
 @decorator
-def retry(call, tries, errors=Exception, timeout=0, filter_errors=None, exp=1, cap=inf, jitter_amp=1):
+def retry(
+    call, tries, errors=Exception, timeout=0, filter_errors=None,
+    exp=1, cap=float("inf"), jitter_amp=1,
+):
     """Makes decorated function retry up to tries times.
        Retries only on specified errors.
        Sleeps timeout or timeout(attempt) seconds between tries.


### PR DESCRIPTION
# Summary
- Enable exponential backoff via keyword arguments.

# Checklist
- [x] Implement unit test cases.

# Reason
- Currently, the feature supports highly customized retry intervals via a pass-in callable argument.
- However, it's hard to comprehend that the argument  `timeout` can also accept a callable object without tracing the source code.
- Capped exponential backoffs and jitter are already well-known approaches, maybe you can consider making them specific features via keyword arguments.