### PR TITLE
docs: Fix a few typos

### DIFF
--- a/funcy/decorators.py
+++ b/funcy/decorators.py
@@ -25,7 +25,7 @@ def decorator(deco):
         return make_decorator(deco)
     elif has_1pos_and_kwonly(deco):
         # Any arguments after first become decorator arguments
-        # And a decorator with arguments is essentialy a decorator fab
+        # And a decorator with arguments is essentially a decorator fab
         def decorator_fab(_func=None, **dkwargs):  # TODO: make _func pos only in Python 3
             if _func is not None:
                 return make_decorator(deco, (), dkwargs)(_func)

--- a/funcy/seqs.py
+++ b/funcy/seqs.py
@@ -130,7 +130,7 @@ def filter(pred, seq):
 
 if PY2:
     # NOTE: Default imap() behaves strange when passed None as function,
-    #       returns 1-length tuples, which is inconvinient and incompatible with map().
+    #       returns 1-length tuples, which is inconvenient and incompatible with map().
     #       This version is more sane: map() compatible and suitable for our internal use.
     def xmap(f, *seqs):
         return _map(make_func(f), *seqs)


### PR DESCRIPTION
There are small typos in:
- funcy/decorators.py
- funcy/seqs.py

Fixes:
- Should read `inconvenient` rather than `inconvinient`.
- Should read `essentially` rather than `essentialy`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md