### PR TITLE
docs: missing parens in log example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,7 @@ Create decorators easily:
 
     @decorator
     def log(call):
-        print call._func.__name__, call._args
+        print(call._func.__name__, call._args)
         return call()
 
 


### PR DESCRIPTION
Great work on this library! I love it.

Small docs fix.