### PR TITLE
docs: add simple invoke example

### DIFF
--- a/docs/colls.rst
+++ b/docs/colls.rst
@@ -308,6 +308,11 @@ Data manipulation
 
     Calls named method with given arguments for each object in ``objects`` and returns an iterator or a list of results.
 
+    For example::
+
+        invoke(['abc', 'def', 'b'], 'find', 'b')
+        # ->[1, -1, 0]
+
 
 Content tests
 -------------


### PR DESCRIPTION
without this it isn't super clear that the name is a string and it's a member of the object list
