### PR TITLE
fix: cut_suffix("") incorrectly returns empty string for any input

### DIFF
--- a/funcy/strings.py
+++ b/funcy/strings.py
@@ -75,4 +75,4 @@ def cut_prefix(s, prefix):
 
 def cut_suffix(s, suffix):
     """Cuts suffix from given string if it's present."""
-    return s[:-len(suffix)] if s.endswith(suffix) else s
+    return s[:-len(suffix)] if suffix and s.endswith(suffix) else s


### PR DESCRIPTION
## Problem

`cut_suffix(s, "")` should return `s` unchanged — an empty string is not a suffix worth removing — but it always returns `""` instead.

```python
>>> cut_suffix("hello", "")
''   # expected: 'hello'
>>> cut_suffix("foo", "")
''   # expected: 'foo'
```

## Root cause

Two things combine to produce the bug:

1. `s.endswith("")` is `True` for **every** string — Python defines the empty string as a suffix of all strings.
2. `s[:-len("")]` = `s[:-0]` = `s[:0]` = `""` — negative indexing with zero wraps around to the start.

## Fix

Guard with `suffix and` before calling `endswith`:

```python
return s[:-len(suffix)] if suffix and s.endswith(suffix) else s
```

Note: `cut_prefix` does **not** share this bug because `s[0:]` correctly returns `s` unchanged.