### PR TITLE
fix: join() raises TypeError when joining bytes collections

### DIFF
--- a/funcy/colls.py
+++ b/funcy/colls.py
@@ -72,7 +72,7 @@ def join(colls):
     cls = dest.__class__
 
     if isinstance(dest, (bytes, str)):
-        return ''.join(colls)
+        return cls().join(colls)
     elif isinstance(dest, Mapping):
         result = dest.copy()
         for d in it:


### PR DESCRIPTION
## Problem

`join([b"foo", b"bar"])` raises `TypeError` instead of returning `b"foobar"`.

```python
>>> join([b"hello", b" ", b"world"])
TypeError: sequence item 0: expected str instance, bytes found
```

## Root cause

The implementation hardcodes `''.join(colls)` — a **str** join — even when the input is a bytes collection. Python's `str.join()` cannot accept bytes items.

```python
if isinstance(dest, (bytes, str)):
    return ''.join(colls)  # BUG: always uses str join
```

## Fix

Use `cls().join(colls)` instead. `cls` is already computed earlier in the function as `dest.__class__`, so this naturally dispatches to `bytes().join()` for bytes and `str().join()` for strings:

```python
if isinstance(dest, (bytes, str)):
    return cls().join(colls)  # FIX: uses the correct type's join
```