### PR TITLE
Fix empty() for str and bytes

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-22.04"
   tools:
     python: "3.11"
 

--- a/funcy/colls.py
+++ b/funcy/colls.py
@@ -49,6 +49,9 @@ def empty(coll):
     """Creates an empty collection of the same type."""
     if isinstance(coll, Iterator):
         return iter([])
+    # str/bytes factory is ''.join; calling it with no args TypeErrors.
+    if isinstance(coll, (bytes, str)):
+        return type(coll)()
     return _factory(coll)()
 
 def iteritems(coll):

--- a/tests/test_colls.py
+++ b/tests/test_colls.py
@@ -354,3 +354,10 @@ def test_pluck_attr():
 
 def test_invoke():
     assert linvoke(['abc', 'def', 'b'], 'find', 'b') == [1, -1, 0]
+
+
+def test_empty_str_bytes():
+    assert empty('abc') == ''
+    assert empty(b'abc') == b''
+    assert empty('') == ''
+    assert empty(b'') == b''


### PR DESCRIPTION
empty hits TypeError when empty(str|bytes) invokes ''.join()/b''.join() with no args. This PR fixes the regression with a focused test covering the case.
