### PR TITLE
Fix join/merge TypeError on bytes sequences

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-22.04"
   tools:
     python: "3.11"
 

--- a/funcy/colls.py
+++ b/funcy/colls.py
@@ -49,6 +49,9 @@ def empty(coll):
     """Creates an empty collection of the same type."""
     if isinstance(coll, Iterator):
         return iter([])
+    # _factory returns ''.join/b''.join, which cannot be called with zero args.
+    if isinstance(coll, (bytes, str)):
+        return type(coll)()
     return _factory(coll)()
 
 def iteritems(coll):
@@ -72,7 +75,8 @@ def join(colls):
     cls = dest.__class__
 
     if isinstance(dest, (bytes, str)):
-        return ''.join(colls)
+        # dest[:0] is '' or b'' so bytes join does not go through str.join.
+        return dest[:0].join(colls)
     elif isinstance(dest, Mapping):
         result = dest.copy()
         for d in it:

--- a/tests/test_colls.py
+++ b/tests/test_colls.py
@@ -29,6 +29,13 @@ def test_empty_iter():
     assert isinstance(it, Iterator)
     assert list(it) == []
 
+def test_empty_str_bytes():
+    assert empty('') == ''
+    assert empty('abc') == ''
+    assert empty(b'') == b''
+    assert empty(b'abc') == b''
+    assert empty(bytearray(b'abc')) == bytearray()
+
 def test_empty_quirks():
     class A:
         FLAG = 1
@@ -56,6 +63,8 @@ def test_join():
     assert join([]) is None
     with pytest.raises(TypeError): join([1])
     assert eq(join(['ab', '', 'cd']), 'abcd')
+    assert eq(join([b'ab', b'', b'cd']), b'abcd')
+    assert eq(merge(b'a', b'bc'), b'abc')
     assert eq(join([['a', 'b'], 'c']), list('abc'))
     assert eq(join([('a', 'b'), ('c',)]), tuple('abc'))
     assert eq(join([{'a': 1}, {'b': 2}]), {'a': 1, 'b': 2})


### PR DESCRIPTION
funcy.colls.join hits TypeError when join([b'a',b'b']) uses str join. This PR fixes the regression with a focused test covering the case.