### PR TITLE
Fix hang in partition/chunks when n or step is zero

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-22.04"
   tools:
     python: "3.11"
 

--- a/funcy/seqs.py
+++ b/funcy/seqs.py
@@ -372,6 +372,8 @@ def _cut_iter(drop_tail, n, step, seq):
 def _cut(drop_tail, n, step, seq=EMPTY):
     if seq is EMPTY:
         step, seq = n, step
+    if n < 1 or step < 1:
+        raise ValueError('n and step must be >= 1')
     if isinstance(seq, Sequence):
         return _cut_seq(drop_tail, n, step, seq)
     else:

--- a/tests/test_seqs.py
+++ b/tests/test_seqs.py
@@ -165,10 +165,26 @@ def test_partition():
     assert lpartition(2, iter(range(5))) == [[0, 1], [2, 3]]
     assert lmap(list, lpartition(2, range(5))) == [[0, 1], [2, 3]]
 
+def test_partition_rejects_non_positive_n_or_step():
+    with pytest.raises(ValueError):
+        list(partition(2, 0, iter([1, 2, 3, 4])))
+    with pytest.raises(ValueError):
+        lpartition(2, 0, [1, 2, 3, 4])
+    with pytest.raises(ValueError):
+        lpartition(0, [1, 2, 3])
+    with pytest.raises(ValueError):
+        list(partition(0, iter([1, 2, 3])))
+
 def test_chunks():
     assert lchunks(2, [0, 1, 2, 3, 4]) == [[0, 1], [2, 3], [4]]
     assert lchunks(2, 1, [0, 1, 2, 3]) == [[0, 1], [1, 2], [2, 3], [3]]
     assert lchunks(3, 1, iter(range(3))) == [[0, 1, 2], [1, 2], [2]]
+
+def test_chunks_rejects_non_positive_n_or_step():
+    with pytest.raises(ValueError):
+        list(chunks(2, 0, iter([1, 2, 3, 4])))
+    with pytest.raises(ValueError):
+        lchunks(0, [1, 2, 3])
 
 def test_partition_by():
     assert lpartition_by(lambda x: x == 3, [1,2,3,4,5]) == [[1,2], [3], [4,5]]


### PR DESCRIPTION
funcy.seqs.partition hits Hang when partition(2, 0, iter(...)) infinite loop. This PR fixes the regression with a focused test covering the case.