### PR TITLE
chore: declare Python 3.14 support in classifiers

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-22.04"
   tools:
     python: "3.11"
 

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
 


### PR DESCRIPTION
## Summary
PyPI classifiers listed support through Python 3.13; declare 3.14 as well so tooling/users can rely on current metadata (issue #162).

## Change
Add `Programming Language :: Python :: 3.14` classifier.

Fixes #162
