### PR TITLE
Fix: get_spec() in funcy/_inspect.py looked up manual arg-spec overrides...

### DIFF
--- a/funcy/_inspect.py
+++ b/funcy/_inspect.py
@@ -94,7 +94,25 @@ ARGS['funcy.colls'] = {
 }
 
 
+# Manual arg-specs for method descriptors of builtin types (e.g. str.endswith),
+# keyed by the owning type's name (func.__objclass__.__name__), mirroring how
+# ARGS[mod] works for module-level builtins above. These cover builtin methods
+# whose __text_signature__ is missing/invalid, so signature() can't handle them.
+ARGS['str'] = {
+    'startswith': 'self,prefix',
+    'endswith': 'self,suffix',
+}
+
+
 Spec = namedtuple("Spec", "max_n names req_n req_names varkw")
+
+
+def _spec_from_str(_spec):
+    required, _, optional = _spec.partition('-')
+    req_names = re.findall(r'\w+|\*', required)  # a list with dups of *
+    max_n = len(req_names) + len(optional)
+    req_n = len(req_names)
+    return Spec(max_n=max_n, names=set(), req_n=req_n, req_names=set(req_names), varkw=False)
 
 
 def get_spec(func, _cache={}):
@@ -105,14 +123,13 @@ def get_spec(func, _cache={}):
         pass
 
     mod = getattr(func, '__module__', None)
+    objclass = getattr(func, '__objclass__', None)
+    objclass_name = getattr(objclass, '__name__', None)
     if mod in STD_MODULES or mod in ARGS and func.__name__ in ARGS[mod]:
-        _spec = ARGS[mod].get(func.__name__, '*')
-        required, _, optional = _spec.partition('-')
-        req_names = re.findall(r'\w+|\*', required)  # a list with dups of *
-        max_n = len(req_names) + len(optional)
-        req_n = len(req_names)
-        spec = Spec(max_n=max_n, names=set(), req_n=req_n, req_names=set(req_names), varkw=False)
-        _cache[func] = spec
+        spec = _cache[func] = _spec_from_str(ARGS[mod].get(func.__name__, '*'))
+        return spec
+    elif objclass_name in ARGS and func.__name__ in ARGS[objclass_name]:
+        spec = _cache[func] = _spec_from_str(ARGS[objclass_name][func.__name__])
         return spec
     elif isinstance(func, type):
         # __init__ inherited from builtin classes

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -56,6 +56,13 @@ def test_rcurry():
     assert rcurry(lambda x,y,z: x+y+z)('a')('b')('c') == 'cba'
     assert rcurry(str.endswith, 2)('c')('abc') is True
 
+def test_rcurry_method_descriptor():
+    # Regression test for https://github.com/Suor/funcy/issues/108 --
+    # get_spec() should introspect method descriptors of builtin types
+    # (which have no __module__) instead of crashing.
+    assert rcurry(str.endswith)('.py')('test.py') is True
+    assert rcurry(str.startswith)('test')('test.py') is True
+
 def test_autocurry():
     at = autocurry(lambda a, b, c: (a, b, c))
 


### PR DESCRIPTION
## Summary
Extended the manual-override mechanism in funcy/_inspect.py: added a `_spec_from_str()` helper factoring out the existing spec-string-to-Spec parsing logic, and a new lookup keyed by `func.__objclass__.__name__` (available on builtin method descriptors) checked alongside the existing module-keyed lookup in get_spec(). Added ARGS['str'] with entries for 'startswith' ('self,prefix') and 'endswith' ('self,suffix') -- the two methods that actually fail signature() introspection on modern CPython. Deliberately did not add str.split/replace/join since those already introspect correctly via signature() (verified: only startswith/endswith raise 'builtin has invalid signature' on this Python version) and adding overrides for them would have dropped their keyword-argument support (used by an existing autocurry(str.split) test), since the override mechanism doesn't track argument names.

## Problem
Suor/funcy issue reference: Suor/funcy#108

## Root Cause
get_spec() in funcy/_inspect.py looked up manual arg-spec overrides only via `mod = getattr(func, '__module__', None)` against the module-keyed ARGS table. str.endswith is a method_descriptor with no __module__ (falls back to None), so it never matched ARGS['builtins']. It also has no __code__ and is not a type, so execution fell through to the final `signature(func)` call, which raises on this descriptor (no valid __text_signature__), and funcy re-raises that as a plain ValueError, masking a fixable introspection gap.

## Testing
PASS - all 206 tests in the full suite pass, including the new regression test and all pre-existing curry/rcurry/autocurry tests.

## Related Issue
Suor/funcy#108
