### PR TITLE
fix: _cut_iter yields wrong-length/wrong-content parts when step > n

### DIFF
--- a/funcy/seqs.py
+++ b/funcy/seqs.py
@@ -363,8 +363,12 @@ def _cut_iter(drop_tail, n, step, seq):
         if len(pool) < n:
             break
         yield pool
-        pool = pool[step:]
-        pool.extend(islice(it, step))
+        if step < n:
+            pool = pool[step:]
+            pool.extend(islice(it, step))
+        else:
+            take(step - n, it)  # discard the gap between parts
+            pool = take(n, it)
     if not drop_tail:
         for item in _cut_seq(drop_tail, n, step, pool):
             yield item

--- a/tests/test_seqs.py
+++ b/tests/test_seqs.py
@@ -170,6 +170,18 @@ def test_chunks():
     assert lchunks(2, 1, [0, 1, 2, 3]) == [[0, 1], [1, 2], [2, 3], [3]]
     assert lchunks(3, 1, iter(range(3))) == [[0, 1, 2], [1, 2], [2]]
 
+def test_partition_step_gt_n():
+    # The iterator path must skip step - n items between parts, like the
+    # Sequence path, when step > n.
+    assert lpartition(2, 3, iter(range(10))) == lpartition(2, 3, list(range(10)))
+    assert lpartition(2, 3, iter(range(10))) == [[0, 1], [3, 4], [6, 7]]
+
+def test_chunks_step_gt_n():
+    # The iterator path must skip step - n items between parts, like the
+    # Sequence path, when step > n.
+    assert lchunks(2, 3, iter(range(10))) == lchunks(2, 3, list(range(10)))
+    assert lchunks(2, 3, iter(range(10))) == [[0, 1], [3, 4], [6, 7], [9]]
+
 def test_partition_by():
     assert lpartition_by(lambda x: x == 3, [1,2,3,4,5]) == [[1,2], [3], [4,5]]
     assert lpartition_by('x', 'abxcd') == [['a', 'b'], ['x'], ['c', 'd']]


### PR DESCRIPTION

## Problem

`partition(n, step, seq)` and `chunks(n, step, seq)` are documented to skip
`step` items between parts. `funcy/seqs.py` implements this with two code
paths dispatched on the input type (`_cut`, line 372-378):

- `_cut_seq` for `Sequence` inputs (e.g. `list`)
- `_cut_iter` for plain iterators (e.g. `iter(...)`, generators)

For `step > n`, the two paths diverge and give different results for the
same logical call, depending only on whether the caller passed a list or an
iterator of the same data.

```python
>>> from funcy import partition
>>> list(partition(2, 3, list(range(10))))   # Sequence path (correct)
[[0, 1], [3, 4], [6, 7]]
>>> list(partition(2, 3, iter(range(10))))   # Iterator path (wrong)
[[0, 1], [2, 3, 4], [5, 6, 7], [8, 9]]
```

The iterator path returns chunks of the wrong length (`[2, 3, 4]` has 3
items, not `n=2`) and wrong content, and even yields a different number of
parts (4 instead of 3). Same divergence reproduces for `chunks`.

## Root cause

`funcy/seqs.py:359-370`, `_cut_iter`, before the fix:

```python
def _cut_iter(drop_tail, n, step, seq):
    it = iter(seq)
    pool = take(n, it)
    while True:
        if len(pool) < n:
            break
        yield pool
        pool = pool[step:]
        pool.extend(islice(it, step))
    if not drop_tail:
        for item in _cut_seq(drop_tail, n, step, pool):
            yield item
```

`pool = pool[step:]; pool.extend(islice(it, step))` implements a sliding
window that only works when `step <= n`: slicing off the first `step`
elements of the `n`-length pool and refilling with `step` fresh elements
from the iterator keeps the pool at length `n` and correctly advances the
window start by `step`.

When `step > n`, `pool[step:]` on an `n`-length pool is always `[]` (Python
list slicing clips silently), so the whole pool is dropped as intended, but
`islice(it, step)` then pulls `step` (not `n`) fresh items from the
iterator into the new pool. This is wrong two ways: the new pool ends up
with `step` items instead of `n`, and the iterator is advanced by `step`
items starting right after the previous pool instead of skipping only the
`step - n` items between the end of one part and the start of the next.

The `Sequence` path (`_cut_seq`, line 355-357) is unaffected because it
computes each part directly from a start index (`seq[i:i+n]` for
`i in range(0, limit, step)`), which is correct for any `n`/`step`
relationship.

## Fix

`funcy/seqs.py:359-370` (`_cut_iter`): branch on `step < n`. Keep the
existing sliding-window logic for `step < n` (unchanged, still correct).
For `step >= n`, explicitly discard the `step - n` items between parts via
`take(step - n, it)`, then take a fresh `n`-item pool via `take(n, it)`.
This also covers `step == n` correctly and equivalently to the prior code
(discarding zero items, then a fresh `take(n, it)`, matching the old
`pool[n:]` + `extend(islice(it, n))` for that case).

```python
def _cut_iter(drop_tail, n, step, seq):
    it = iter(seq)
    pool = take(n, it)
    while True:
        if len(pool) < n:
            break
        yield pool
        if step < n:
            pool = pool[step:]
            pool.extend(islice(it, step))
        else:
            take(step - n, it)  # discard the gap between parts
            pool = take(n, it)
    if not drop_tail:
        for item in _cut_seq(drop_tail, n, step, pool):
            yield item
```
