### PR TITLE
Fix once_per handling of unhashable arguments

### DIFF
--- a/funcy/flow.py
+++ b/funcy/flow.py
@@ -1,4 +1,3 @@
-from collections.abc import Hashable
 from datetime import datetime, timedelta
 import time
 import threading
@@ -220,10 +219,12 @@ def once_per(*argnames):
         def wrapper(*args, **kwargs):
             with lock:
                 values = tuple(get_arg(name, args, kwargs) for name in argnames)
-                if isinstance(values, Hashable):
-                    done, add = done_set, done_set.add
-                else:
+                try:
+                    hash(values)
+                except TypeError:
                     done, add = done_list, done_list.append
+                else:
+                    done, add = done_set, done_set.add
 
                 if values not in done:
                     add(values)

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -241,6 +241,23 @@ def test_once_per_args():
     assert calls == [1, 2, 1]
 
 
+@pytest.mark.parametrize('decorate', [once_per('n'), once_per_args])
+@pytest.mark.parametrize('make_value', [list, dict, set, lambda: ([],)])
+def test_once_per_unhashable_arguments(decorate, make_value):
+    calls = []
+
+    @decorate
+    def call(n):
+        calls.append(n)
+        return 'called'
+
+    assert call(make_value()) == 'called'
+    assert call(n=make_value()) is None
+    assert call('other') == 'called'
+    assert call('other') is None
+    assert calls == [make_value(), 'other']
+
+
 def test_wrap_with():
     calls = []
 


### PR DESCRIPTION
`once_per()` and `once_per_args()` raise `TypeError` before calling the wrapped function when an argument is a list, dictionary, set, or tuple containing an unhashable value. For example:

```python
@once_per_args
def initialize(items):
    return len(items)

initialize([1, 2])  # TypeError: unhashable type: 'list'
```

The argument tuple always satisfies `collections.abc.Hashable`, even when hashing its contents fails. Check whether it can actually be hashed so these calls reach the existing list-based fallback. Equal argument values still suppress repeated calls.

Validation: all eight regression cases fail on the original implementation; `pytest -W error` passes all 213 tests after the fix. Both CI flake8 commands pass.

Prepared with assistance from OpenAI Codex.
