### PR TITLE
Preserve custom keys when calling memoize directly

### DIFF
--- a/funcy/calc.py
+++ b/funcy/calc.py
@@ -25,7 +25,7 @@ def memoize(_func=None, *, key_func=None):
     Exposes its memory via .memory attribute.
     """
     if _func is not None:
-        return memoize()(_func)
+        return memoize(key_func=key_func)(_func)
     return _memory_decorator({}, key_func)
 
 memoize.skip = SkipMemory

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -88,6 +88,23 @@ def test_memoize_key_func():
     assert calls == ['a', 'ab']
 
 
+def test_memoize_direct_key_func():
+    calls = []
+
+    def total(values):
+        calls.append(list(values))
+        return sum(values)
+
+    cached_total = memoize(total, key_func=tuple)
+    assert cached_total([1, 2]) == 3
+    assert cached_total([1, 2]) == 3
+    assert calls == [[1, 2]]
+
+    cached_total.invalidate([1, 2])
+    assert cached_total([1, 2]) == 3
+    assert calls == [[1, 2], [1, 2]]
+
+
 def test_make_lookuper():
     @make_lookuper
     def letter_index():


### PR DESCRIPTION
Calling `memoize(func, key_func=...)` silently discards the key function. A list argument consequently raises `TypeError`, even when the supplied key function converts it to a hashable tuple. Forward `key_func` through the direct-call form, just as the decorator form already does.

The regression test covers repeated calls with unhashable inputs and invalidating the custom key. It fails on the base revision and passes with this change.

Validation: Python 3.12, all 206 tests pass with warnings treated as errors; both flake8 commands from the lint environment and `git diff --check` pass.

Disclosure: Codex implemented and tested this change under the submitting account's authorization.

Upstream CI note: GitHub lint, documentation, and Python 3.7–3.13/PyPy jobs pass. Read the Docs rejects the repository's existing `build.os: ubuntu-20.04` setting before running the build; its public build notification identifies an unsupported OS configuration. Two legacy Ubuntu 20.04 Python jobs remain queued.
