### PR TITLE
Preserve refilled cache values during stale expiration

### DIFF
--- a/funcy/calc.py
+++ b/funcy/calc.py
@@ -92,8 +92,11 @@ class CacheMemory(dict):
     def expire(self):
         i = bisect(self._expires, time.time())
         for _ in range(i):
-            self._expires.popleft()
-            self.pop(self._keys.popleft(), None)
+            expires_at = self._expires.popleft()
+            key = self._keys.popleft()
+            entry = dict.get(self, key)
+            if entry is not None and entry[1] <= expires_at:
+                self.pop(key, None)
 
     def clear(self):
         dict.clear(self)

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -88,6 +88,32 @@ def test_memoize_key_func():
     assert calls == ['a', 'ab']
 
 
+def test_cache_expiration_preserves_refilled_key(monkeypatch):
+    now = [0]
+    monkeypatch.setattr('funcy.calc.time.time', lambda: now[0])
+    calls = []
+
+    @cache(10)
+    def cached(key):
+        calls.append(key)
+        return len(calls)
+
+    assert cached('refilled') == 1
+    assert cached('expired') == 2
+    now[0] = 5
+    cached.invalidate('refilled')
+    assert cached('refilled') == 3
+
+    now[0] = 10
+    assert cached('expired') == 4
+    assert cached('refilled') == 3
+    assert calls == ['refilled', 'expired', 'refilled', 'expired']
+
+    now[0] = 15
+    assert cached('refilled') == 5
+    assert cached('expired') == 4
+
+
 def test_make_lookuper():
     @make_lookuper
     def letter_index():


### PR DESCRIPTION
After `cached.invalidate(key)` and refilling that key, the old expiration queue entry can delete the new value when another entry expires. Keep a refilled entry when its expiration time is later than the queued expiration being processed.

The regression uses a controlled clock: invalidate and refill halfway through the timeout, expire a different key, confirm the refilled value survives, then confirm it expires at its own deadline. It fails on the base revision and passes with this change.

Validation: Python 3.12, all 206 tests pass with warnings treated as errors; both flake8 commands from the lint environment and `git diff --check` pass.

Disclosure: Codex implemented and tested this change under the submitting account's authorization.

Upstream CI note: GitHub lint, documentation, and Python 3.7–3.13/PyPy jobs pass. Read the Docs rejects the repository's existing `build.os: ubuntu-20.04` setting before running the build; its public build notification identifies an unsupported OS configuration. Two legacy Ubuntu 20.04 Python jobs remain queued.
