### PR TITLE
Keep reused cache decorators independent

### DIFF
--- a/funcy/calc.py
+++ b/funcy/calc.py
@@ -26,7 +26,7 @@ def memoize(_func=None, *, key_func=None):
     """
     if _func is not None:
         return memoize(key_func=key_func)(_func)
-    return _memory_decorator({}, key_func)
+    return _memory_decorator(dict, key_func)
 
 memoize.skip = SkipMemory
 
@@ -36,13 +36,15 @@ def cache(timeout, *, key_func=None):
     if isinstance(timeout, timedelta):
         timeout = timeout.total_seconds()
 
-    return _memory_decorator(CacheMemory(timeout), key_func)
+    return _memory_decorator(lambda: CacheMemory(timeout), key_func)
 
 cache.skip = SkipMemory
 
 
-def _memory_decorator(memory, key_func):
+def _memory_decorator(memory_factory, key_func):
     def decorator(func):
+        memory = memory_factory()
+
         @wraps(func)
         def wrapper(*args, **kwargs):
             # We inline this here since @memoize also targets microoptimizations

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -105,6 +105,37 @@ def test_memoize_direct_key_func():
     assert calls == [[1, 2], [1, 2]]
 
 
+@pytest.mark.parametrize('deco', [memoize(), cache(60)], ids=['memoize', 'cache'])
+def test_reused_memory_decorator(deco):
+    calls = []
+
+    @deco
+    def inc(x):
+        calls.append('inc')
+        return x + 1
+
+    @deco
+    def double(x):
+        calls.append('double')
+        return x * 2
+
+    assert inc(3) == 4
+    assert double(3) == 6
+    assert inc(3) == 4
+    assert double(3) == 6
+    assert calls == ['inc', 'double']
+
+    inc.invalidate(3)
+    assert double(3) == 6
+    assert inc(3) == 4
+    assert calls == ['inc', 'double', 'inc']
+
+    inc.invalidate_all()
+    assert double(3) == 6
+    assert inc(3) == 4
+    assert calls == ['inc', 'double', 'inc', 'inc']
+
+
 def test_make_lookuper():
     @make_lookuper
     def letter_index():


### PR DESCRIPTION
Reusing a configured decorator currently lets different functions share cached results:

```python
cached = cache(60)
inc = cached(lambda x: x + 1)
double = cached(lambda x: x * 2)

inc(3)     # 4
double(3)  # 4, but should be 6
```

The same problem affects `memoize()`. Create the memory when the decorator is applied to each function, so reusing a timeout or key configuration keeps the functions' cached values and invalidation separate. The cache-hit path stays unchanged.

The regression test covers both decorators, repeated calls, and `invalidate()` / `invalidate_all()` affecting only their own function. Both cases fail before the fix. On Python 3.12, `python -m pytest -W error -q` passes all 221 tests, and both flake8 commands from the repository's CI pass.
