### PR TITLE
Avoid deadlocks in reentrant once-decorated functions

### DIFF
--- a/funcy/flow.py
+++ b/funcy/flow.py
@@ -209,7 +209,7 @@ def joining(call, sep):
 def once_per(*argnames):
     """Call function only once for every combination of the given arguments."""
     def once(func):
-        lock = threading.Lock()
+        lock = threading.RLock()
         done_set = set()
         done_list = list()
 

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from threading import Thread
 import pytest
 from funcy.flow import *
 
@@ -276,3 +277,34 @@ def test_wrap_with():
 
     calc()
     assert calls == [1]
+
+
+@pytest.mark.parametrize('decorate, expected', [
+    (once, [2]),
+    (once_per('n'), [2, 1, 0]),
+    (once_per_args, [2, 1, 0]),
+])
+def test_once_allows_reentrant_calls(decorate, expected):
+    calls = []
+    errors = []
+
+    @decorate
+    def initialize(n):
+        calls.append(n)
+        if n:
+            initialize(n - 1)
+
+    def run():
+        try:
+            initialize(2)
+            initialize(2)
+        except Exception as error:
+            errors.append(error)
+
+    worker = Thread(target=run)
+    worker.daemon = True
+    worker.start()
+    worker.join(5)
+    assert not worker.is_alive(), 'reentrant call deadlocked'
+    assert not errors
+    assert calls == expected


### PR DESCRIPTION
A function decorated with `once`, `once_per`, or `once_per_args` deadlocks if it calls itself: the wrapper holds a non-reentrant lock while executing the function, and the nested call tries to acquire that same lock.

Use an RLock so a same-thread nested call can reach the existing argument check. Previously seen arguments are still skipped; new arguments can initialize recursively. Calls from other threads remain serialized.

Added bounded thread tests for all three decorators, including a second call to confirm that completed arguments are not executed again. All three tests fail before the change instead of hanging the suite.

Validation: 222 tests pass with warnings treated as errors on Python 3.10 and 3.14. Both flake8 commands from tox.ini pass.
