### PR TITLE
Handle fractional-second error rate timeouts

### DIFF
--- a/funcy/flow.py
+++ b/funcy/flow.py
@@ -136,7 +136,7 @@ class ErrorRateExceeded(Exception):
 def limit_error_rate(fails, timeout, exception=ErrorRateExceeded):
     """If function fails to complete fails times in a row,
        calls to it will be intercepted for timeout with exception raised instead."""
-    if isinstance(timeout, int):
+    if isinstance(timeout, (int, float)):
         timeout = timedelta(seconds=timeout)
 
     def decorator(func):

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -276,3 +276,19 @@ def test_wrap_with():
 
     calc()
     assert calls == [1]
+
+
+@pytest.mark.parametrize('timeout', [0.5, timedelta(seconds=0.5)])
+def test_limit_error_rate_fractional_timeout(timeout):
+    @limit_error_rate(1, timeout)
+    def fail():
+        raise MyError
+
+    with pytest.raises(MyError):
+        fail()
+    with pytest.raises(ErrorRateExceeded):
+        fail()
+
+    fail.blocked -= timedelta(seconds=1)
+    with pytest.raises(MyError):
+        fail()


### PR DESCRIPTION
A fractional timeout such as `@limit_error_rate(1, 0.5)` raises TypeError on the first blocked call, instead of ErrorRateExceeded. Only integer timeouts are converted to timedeltas, leaving the wrapper to compare a timedelta with a float.

Convert floating-point seconds as well. The regression checks blocking and expiry with `0.5` seconds and the equivalent timedelta, without sleeping.

Validation: the float case fails before the fix; all 221 tests pass with warnings treated as errors on Python 3.10 and 3.14. Both flake8 commands from tox.ini pass.
